### PR TITLE
Adding control for player details toggling + player details health toggling

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -20,8 +20,8 @@
     "LIGHTSOUTSD.config_visibility_option_2": "Players and GM",
 	"LIGHTSOUTSD.config_icon_high_contrast_mode": "High Contrast Mode for Icons",
 	"LIGHTSOUTSD.config_icon_high_contrast_mode_help": "[EXPERIMENTAL] This setting enables a grayscale high contrast filter for all icons. It can be used to achieve more Shadowdark-style iconography while still using colored icons.",
-	"LIGHTSOUTSD.config_party_details_visibility": "Display Party Details",
-	"LIGHTSOUTSD.config_party_details_visibility_help": "Toggle whether to show party details on left side of screen",
-	"LIGHTSOUTSD.config_party_details_health_visibility": "Display Party Details - Health",
-	"LIGHTSOUTSD.config_party_details_health_visibility_help": "Toggle whether to show player health in party details on left side of screen"
+	"LIGHTSOUTSD.config_party_panel_visibility": "Party Panel Visibility",
+	"LIGHTSOUTSD.config_party_panel_visibility_help": "Controls who can see party details on left side of screen.",
+	"LIGHTSOUTSD.config_hide_party_health": "Hide Party Health",
+	"LIGHTSOUTSD.config_hide_party_health_help": "Disable showing party members' health in the party panel."
 }

--- a/languages/en.json
+++ b/languages/en.json
@@ -19,5 +19,7 @@
     "LIGHTSOUTSD.config_visibility_option_1": "GM Only",
     "LIGHTSOUTSD.config_visibility_option_2": "Players and GM",
 	"LIGHTSOUTSD.config_icon_high_contrast_mode": "High Contrast Mode for Icons",
-	"LIGHTSOUTSD.config_icon_high_contrast_mode_help": "[EXPERIMENTAL] This setting enables a grayscale high contrast filter for all icons. It can be used to achieve more Shadowdark-style iconography while still using colored icons."
+	"LIGHTSOUTSD.config_icon_high_contrast_mode_help": "[EXPERIMENTAL] This setting enables a grayscale high contrast filter for all icons. It can be used to achieve more Shadowdark-style iconography while still using colored icons.",
+	"LIGHTSOUTSD.config_party_details_visibility": "Display Party Details",
+	"LIGHTSOUTSD.config_party_details_visibility_help": "Toggle whether to show player party details on left side of screen"
 }

--- a/languages/en.json
+++ b/languages/en.json
@@ -21,5 +21,7 @@
 	"LIGHTSOUTSD.config_icon_high_contrast_mode": "High Contrast Mode for Icons",
 	"LIGHTSOUTSD.config_icon_high_contrast_mode_help": "[EXPERIMENTAL] This setting enables a grayscale high contrast filter for all icons. It can be used to achieve more Shadowdark-style iconography while still using colored icons.",
 	"LIGHTSOUTSD.config_party_details_visibility": "Display Party Details",
-	"LIGHTSOUTSD.config_party_details_visibility_help": "Toggle whether to show player party details on left side of screen"
+	"LIGHTSOUTSD.config_party_details_visibility_help": "Toggle whether to show party details on left side of screen",
+	"LIGHTSOUTSD.config_party_details_health_visibility": "Display Party Details - Health",
+	"LIGHTSOUTSD.config_party_details_health_visibility_help": "Toggle whether to show player health in party details on left side of screen"
 }

--- a/languages/en.json
+++ b/languages/en.json
@@ -10,18 +10,18 @@
 	"LIGHTSOUTSD.config_disable_gm_selected_token": "Hide GM's Selected Token",
 	"LIGHTSOUTSD.config_disable_gm_selected_token_help": "Disable showing GM's selected token information in the character panel.",
     "LIGHTSOUTSD.config_hotbar_visibility": "Hotbar Visibility",
-    "LIGHTSOUTSD.config_hotbar_visibility_help": "Controls who can see the Hotbar.",
+    "LIGHTSOUTSD.config_hotbar_visibility_help": "Controls who can see the Foundry Hotbar.",
     "LIGHTSOUTSD.config_player_list_visibility": "Players List Visibility",
-    "LIGHTSOUTSD.config_player_list_visibility_help": "Controls who can see the the Player List.",
+    "LIGHTSOUTSD.config_player_list_visibility_help": "Controls who can see the the Foundry Player List.",
     "LIGHTSOUTSD.config_navbar_visibility": "Scene Navigation Visibility",
-    "LIGHTSOUTSD.config_navbar_visibility_help": "Controls who can see the the Scene Navigation.",
+    "LIGHTSOUTSD.config_navbar_visibility_help": "Controls who can see the the Foundry Scene Navigation.",
     "LIGHTSOUTSD.config_visibility_option_0": "None",
     "LIGHTSOUTSD.config_visibility_option_1": "GM Only",
     "LIGHTSOUTSD.config_visibility_option_2": "Players and GM",
 	"LIGHTSOUTSD.config_icon_high_contrast_mode": "High Contrast Mode for Icons",
 	"LIGHTSOUTSD.config_icon_high_contrast_mode_help": "[EXPERIMENTAL] This setting enables a grayscale high contrast filter for all icons. It can be used to achieve more Shadowdark-style iconography while still using colored icons.",
 	"LIGHTSOUTSD.config_party_panel_visibility": "Party Panel Visibility",
-	"LIGHTSOUTSD.config_party_panel_visibility_help": "Controls who can see party details on left side of screen.",
+	"LIGHTSOUTSD.config_party_panel_visibility_help": "Controls who can see the Lights Out Party Panel.",
 	"LIGHTSOUTSD.config_hide_party_health": "Hide Party Health",
-	"LIGHTSOUTSD.config_hide_party_health_help": "Disable showing party members' health in the party panel."
+	"LIGHTSOUTSD.config_hide_party_health_help": "Disable showing party members' health in the Lights Out Party Panel. Players can still see their own health."
 }

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
-    "id": "lights-out-theme-shadowdark",
-    "title": "Shadowdark Lights Out Theme",
+    "id": "lights-out-theme-shadowdark-ph-testing",
+    "title": "Shadowdark Lights Out Theme PH Testing",
     "description": "A darker and polished UI theme for Shadowdark with party and character panels.",
     "version": "1.14",
     "authors": [
@@ -84,8 +84,8 @@
     },
     "bugs": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/issues",
     "changelog": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/releases",
-    "download": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/releases/download/v1.14/module.zip",
-    "manifest": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/releases/latest/download/module.json",
+    "download": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-1/module.zip",
+    "manifest": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-1/module.json",
     "readme": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/blob/main/README.md",
     "url": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark"
-}   
+}

--- a/module.json
+++ b/module.json
@@ -84,8 +84,8 @@
     },
     "bugs": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/issues",
     "changelog": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/releases",
-    "download": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-11/module.zip",
-    "manifest": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-11/module.json",
+    "download": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-12/module.zip",
+    "manifest": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-12/module.json",
     "readme": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/blob/main/README.md",
     "url": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark"
 }

--- a/module.json
+++ b/module.json
@@ -84,8 +84,8 @@
     },
     "bugs": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/issues",
     "changelog": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/releases",
-    "download": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-4/module.zip",
-    "manifest": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-4/module.json",
+    "download": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-5/module.zip",
+    "manifest": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-5/module.json",
     "readme": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/blob/main/README.md",
     "url": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark"
 }

--- a/module.json
+++ b/module.json
@@ -84,8 +84,8 @@
     },
     "bugs": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/issues",
     "changelog": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/releases",
-    "download": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-2/module.zip",
-    "manifest": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-2/module.json",
+    "download": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-3/module.zip",
+    "manifest": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-3/module.json",
     "readme": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/blob/main/README.md",
     "url": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark"
 }

--- a/module.json
+++ b/module.json
@@ -84,8 +84,8 @@
     },
     "bugs": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/issues",
     "changelog": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/releases",
-    "download": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-5/module.zip",
-    "manifest": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-5/module.json",
+    "download": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-11/module.zip",
+    "manifest": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-11/module.json",
     "readme": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/blob/main/README.md",
     "url": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark"
 }

--- a/module.json
+++ b/module.json
@@ -84,8 +84,8 @@
     },
     "bugs": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/issues",
     "changelog": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/releases",
-    "download": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-1/module.zip",
-    "manifest": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-1/module.json",
+    "download": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-2/module.zip",
+    "manifest": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-2/module.json",
     "readme": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/blob/main/README.md",
     "url": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark"
 }

--- a/module.json
+++ b/module.json
@@ -84,8 +84,8 @@
     },
     "bugs": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/issues",
     "changelog": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/releases",
-    "download": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-3/module.zip",
-    "manifest": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-3/module.json",
+    "download": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-4/module.zip",
+    "manifest": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-4/module.json",
     "readme": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/blob/main/README.md",
     "url": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark"
 }

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
-    "id": "lights-out-theme-shadowdark-ph-testing",
-    "title": "Shadowdark Lights Out Theme PH Testing",
+    "id": "lights-out-theme-shadowdark",
+    "title": "Shadowdark Lights Out Theme",
     "description": "A darker and polished UI theme for Shadowdark with party and character panels.",
     "version": "1.14",
     "authors": [
@@ -84,8 +84,8 @@
     },
     "bugs": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/issues",
     "changelog": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/releases",
-    "download": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-12/module.zip",
-    "manifest": "https://github.com/PhillypHenning/foundryvtt-lights-out-theme-shadowdark/releases/download/testing-12/module.json",
+    "download": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/releases/download/v1.14/module.zip",
+    "manifest": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/releases/latest/download/module.json",
     "readme": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/blob/main/README.md",
     "url": "https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark"
-}
+}   

--- a/scripts/apps/PartyPanelApp.js
+++ b/scripts/apps/PartyPanelApp.js
@@ -34,7 +34,13 @@ export class PartyPanelApp extends HandlebarsApplicationMixin(ApplicationV2) {
     }
 
     _prepareContext(options) {
+        const hidePartyHealth = game.settings.get("lights-out-theme-shadowdark", "hide_party_health");
+        const isGM = game.user.isGM;
+        const userCharacterId = game.user.character?.id;
+
         return {
+            hidePartyHealth: isGM ? false : hidePartyHealth, // GMs always sees health
+            userCharacterId: userCharacterId,
             characters: this.partyData
         };
     }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -242,7 +242,9 @@ async function renderParty() {
   const characters = await Promise.all(getPartyCharacters().map(characterData));
   const partyVisibility = game.settings.get("lights-out-theme-shadowdark", "party_details_config")
   console.log("partyVisibility:", partyVisibility); // Should be true/false
-  typeof game.settings.get("lights-out-theme-shadowdark", "party_details_config")
+  console.log("settings typeof:", typeof game.settings.get("lights-out-theme-shadowdark", "party_details_config"))
+  console.log("partyVisibility typeof:", typeof game.settings.get("lights-out-theme-shadowdark", "party_details_config"))
+
 
   const tpl = await renderTemplate("modules/lights-out-theme-shadowdark/templates/party.hbs", {
     characters,

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -241,14 +241,13 @@ async function renderParty() {
 
   const characters = await Promise.all(getPartyCharacters().map(characterData));
   const partyVisibility = game.settings.get("lights-out-theme-shadowdark", "party_details_config")
-  console.log("partyVisibility:", partyVisibility); // Should be true/false
-  console.log("settings typeof:", typeof game.settings.get("lights-out-theme-shadowdark", "party_details_config"))
-  console.log("partyVisibility typeof:", typeof game.settings.get("lights-out-theme-shadowdark", "party_details_config"))
-
+  const playerHealthVisibility = game.settings.get("lights-out-theme-shadowdark", "party_details_health_config")
+  console.log("playerHealthVisibility: ", playerHealthVisibility)
 
   const tpl = await renderTemplate("modules/lights-out-theme-shadowdark-ph-testing/templates/party.hbs", {
     characters,
-    partyVisibility
+    partyVisibility,
+    playerHealthVisibility
   });
 
   elem.innerHTML = tpl;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -160,10 +160,13 @@ async function renderCharacter(selection = false) {
 }
 
 async function renderParty() {
+  const partyVisibility = game.settings.get("lights-out-theme-shadowdark", "party_panel_visibility");
+  if (partyVisibility < userPermission()) {
+    game.lightsOutTheme.partyPanel.close();
+    return;
+  }
+  
   const characters = await Promise.all(getPartyCharacters().map(characterData));
-  const partyVisibility = game.settings.get("lights-out-theme-shadowdark", "party_details_config")
-  const playerHealthVisibility = game.settings.get("lights-out-theme-shadowdark", "party_details_health_config")
-
   game.lightsOutTheme.partyPanel.updateData(characters);
 }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -242,7 +242,6 @@ async function renderParty() {
   const characters = await Promise.all(getPartyCharacters().map(characterData));
   const partyVisibility = game.settings.get("lights-out-theme-shadowdark", "party_details_config")
   const playerHealthVisibility = game.settings.get("lights-out-theme-shadowdark", "party_details_health_config")
-  console.log("playerHealthVisibility: ", playerHealthVisibility)
 
   const tpl = await renderTemplate("modules/lights-out-theme-shadowdark-ph-testing/templates/party.hbs", {
     characters,

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -241,6 +241,8 @@ async function renderParty() {
 
   const characters = await Promise.all(getPartyCharacters().map(characterData));
   const partyVisibility = game.settings.get("lights-out-theme-shadowdark", "party_details_config")
+  console.log("partyVisibility:", partyVisibility); // Should be true/false
+  typeof game.settings.get("lights-out-theme-shadowdark", "party_details_config")
 
   const tpl = await renderTemplate("modules/lights-out-theme-shadowdark/templates/party.hbs", {
     characters,

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -240,9 +240,11 @@ async function renderParty() {
   if (!elem) return;
 
   const characters = await Promise.all(getPartyCharacters().map(characterData));
+  const partyVisibility = game.settings.get("lights-out-theme-shadowdark", "party_details_config")
 
   const tpl = await renderTemplate("modules/lights-out-theme-shadowdark/templates/party.hbs", {
-    characters
+    characters,
+    partyVisibility
   });
 
   elem.innerHTML = tpl;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -13,8 +13,8 @@ Hooks.once("init", async () => {
     $("section#ui-left").append('<div id="party"></div>');
   
     await loadTemplates([
-      "modules/lights-out-theme-shadowdark/templates/character.hbs",
-      "modules/lights-out-theme-shadowdark/templates/party.hbs",
+      "modules/lights-out-theme-shadowdark-ph-testing/templates/character.hbs",
+      "modules/lights-out-theme-shadowdark-ph-testing/templates/party.hbs",
     ]);
   
     activatePlayerListeners();
@@ -246,7 +246,7 @@ async function renderParty() {
   console.log("partyVisibility typeof:", typeof game.settings.get("lights-out-theme-shadowdark", "party_details_config"))
 
 
-  const tpl = await renderTemplate("modules/lights-out-theme-shadowdark/templates/party.hbs", {
+  const tpl = await renderTemplate("modules/lights-out-theme-shadowdark-ph-testing/templates/party.hbs", {
     characters,
     partyVisibility
   });

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -13,8 +13,8 @@ Hooks.once("init", async () => {
     $("section#ui-left").append('<div id="party"></div>');
   
     await loadTemplates([
-      "modules/lights-out-theme-shadowdark-ph-testing/templates/character.hbs",
-      "modules/lights-out-theme-shadowdark-ph-testing/templates/party.hbs",
+      "modules/lights-out-theme-shadowdark/templates/character.hbs",
+      "modules/lights-out-theme-shadowdark/templates/party.hbs",
     ]);
   
     activatePlayerListeners();
@@ -243,7 +243,7 @@ async function renderParty() {
   const partyVisibility = game.settings.get("lights-out-theme-shadowdark", "party_details_config")
   const playerHealthVisibility = game.settings.get("lights-out-theme-shadowdark", "party_details_health_config")
 
-  const tpl = await renderTemplate("modules/lights-out-theme-shadowdark-ph-testing/templates/party.hbs", {
+  const tpl = await renderTemplate("modules/lights-out-theme-shadowdark/templates/party.hbs", {
     characters,
     partyVisibility,
     playerHealthVisibility

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -83,23 +83,28 @@ export function registerSettings() {
         default: false
     });
 
-    game.settings.register("lights-out-theme-shadowdark", "party_details_config", {
-        name: game.i18n.localize("LIGHTSOUTSD.config_party_details_visibility"),
-        hint: game.i18n.localize("LIGHTSOUTSD.config_party_details_visibility_help"),
+    game.settings.register("lights-out-theme-shadowdark", 'party_panel_visibility', {
+        name: game.i18n.localize("LIGHTSOUTSD.config_party_panel_visibility"),
+        hint: game.i18n.localize("LIGHTSOUTSD.config_party_panel_visibility_help"),
         scope: "world",
         config: true,
         requiresReload: true,
-        type: Boolean,
-        default: true
-    });
+        type: Number,
+        choices: {
+            0: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_0"),
+            1: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_1"),
+            2: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_2")
+        },
+        default: 2
+      });
     
-    game.settings.register("lights-out-theme-shadowdark", "party_details_health_config", {
-        name: game.i18n.localize("LIGHTSOUTSD.config_party_details_health_visibility"),
-        hint: game.i18n.localize("LIGHTSOUTSD.config_party_details_health_visibility_help"),
+    game.settings.register("lights-out-theme-shadowdark", "hide_party_health", {
+        name: game.i18n.localize("LIGHTSOUTSD.config_hide_party_health"),
+        hint: game.i18n.localize("LIGHTSOUTSD.config_hide_party_health_help"),
         scope: "world",
         config: true,
         requiresReload: true,
         type: Boolean,
-        default: true
+        default: false
     });
 }

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -82,4 +82,14 @@ export function registerSettings() {
         type: Boolean,
         default: false
     });
+
+    game.settings.register("lights-out-theme-shadowdark", "party_details_config", {
+        name: game.i18n.localize("LIGHTSOUTSD.config_party_details_visibility"),
+        hint: game.i18n.localize("LIGHTSOUTSD.config_party_details_visibility_help"),
+        scope: "world",
+        config: true,
+        requiresReload: true,
+        type: Boolean,
+        default: true
+    });
 }

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -92,4 +92,14 @@ export function registerSettings() {
         type: Boolean,
         default: true
     });
+    
+    game.settings.register("lights-out-theme-shadowdark", "party_details_health_config", {
+        name: game.i18n.localize("LIGHTSOUTSD.config_party_details_health_visibility"),
+        hint: game.i18n.localize("LIGHTSOUTSD.config_party_details_health_visibility_help"),
+        scope: "world",
+        config: true,
+        requiresReload: true,
+        type: Boolean,
+        default: true
+    });
 }

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -1,9 +1,81 @@
 export function registerSettings() {
+
+    game.settings.register("lights-out-theme-shadowdark", 'party_panel_visibility', {
+        name: game.i18n.localize("LIGHTSOUTSD.config_party_panel_visibility"),
+        hint: game.i18n.localize("LIGHTSOUTSD.config_party_panel_visibility_help"),
+        scope: "world",
+        config: true,
+        requiresReload: true,
+        type: Number,
+        choices: {
+            0: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_0"),
+            1: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_1"),
+            2: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_2")
+        },
+        default: 2
+    });
+
+    game.settings.register("lights-out-theme-shadowdark", 'hotbar_visibility', {
+        name: game.i18n.localize("LIGHTSOUTSD.config_hotbar_visibility"),
+        hint: game.i18n.localize("LIGHTSOUTSD.config_hotbar_visibility_help"),
+        scope: "world",
+        config: true,
+        requiresReload: true,
+        type: Number,
+        choices: {
+            0: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_0"),
+            1: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_1"),
+            2: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_2")
+        },
+        default: 2
+      });
+
+    game.settings.register("lights-out-theme-shadowdark", 'navbar_visibility', {
+        name: game.i18n.localize("LIGHTSOUTSD.config_navbar_visibility"),
+        hint: game.i18n.localize("LIGHTSOUTSD.config_navbar_visibility_help"),
+        scope: "world",
+        config: true,
+        requiresReload: true,
+        type: Number, 
+        choices: {
+            0: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_0"),
+            1: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_1"),
+            2: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_2")
+        },
+        default: 0
+    });
+
+    
+    game.settings.register("lights-out-theme-shadowdark", 'players_list_visibility', {
+        name: game.i18n.localize("LIGHTSOUTSD.config_player_list_visibility"),
+        hint: game.i18n.localize("LIGHTSOUTSD.config_player_list_visibility_help"),
+        scope: "world",
+        config: true,
+        requiresReload: true,
+        type: Number,
+        choices: {
+            0: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_0"),
+            1: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_1"),
+            2: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_2")
+        },
+        default: 2
+    });
+
     game.settings.register("lights-out-theme-shadowdark", "party-only-active", {
         name: game.i18n.localize("LIGHTSOUTSD.config_party_only_active"),
         hint: game.i18n.localize("LIGHTSOUTSD.config_party_only_active_help"),
         scope: "world",
         config: true,
+        type: Boolean,
+        default: false
+    });
+
+    game.settings.register("lights-out-theme-shadowdark", "hide_party_health", {
+        name: game.i18n.localize("LIGHTSOUTSD.config_hide_party_health"),
+        hint: game.i18n.localize("LIGHTSOUTSD.config_hide_party_health_help"),
+        scope: "world",
+        config: true,
+        requiresReload: true,
         type: Boolean,
         default: false
     });
@@ -28,79 +100,9 @@ export function registerSettings() {
         default: false
     });
 
-    game.settings.register("lights-out-theme-shadowdark", 'hotbar_visibility', {
-        name: game.i18n.localize("LIGHTSOUTSD.config_hotbar_visibility"),
-        hint: game.i18n.localize("LIGHTSOUTSD.config_hotbar_visibility_help"),
-        scope: "world",
-        config: true,
-        requiresReload: true,
-        type: Number,
-        choices: {
-            0: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_0"),
-            1: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_1"),
-            2: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_2")
-        },
-        default: 2
-      });
-      
-    game.settings.register("lights-out-theme-shadowdark", 'players_list_visibility', {
-        name: game.i18n.localize("LIGHTSOUTSD.config_player_list_visibility"),
-        hint: game.i18n.localize("LIGHTSOUTSD.config_player_list_visibility_help"),
-        scope: "world",
-        config: true,
-        requiresReload: true,
-        type: Number,
-        choices: {
-            0: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_0"),
-            1: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_1"),
-            2: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_2")
-        },
-        default: 2
-    });
-
-    game.settings.register("lights-out-theme-shadowdark", 'navbar_visibility', {
-        name: game.i18n.localize("LIGHTSOUTSD.config_navbar_visibility"),
-        hint: game.i18n.localize("LIGHTSOUTSD.config_navbar_visibility_help"),
-        scope: "world",
-        config: true,
-        requiresReload: true,
-        type: Number, 
-        choices: {
-            0: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_0"),
-            1: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_1"),
-            2: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_2")
-        },
-        default: 0
-    });
-
     game.settings.register("lights-out-theme-shadowdark", "icon-high-contrast-mode", {
         name: game.i18n.localize("LIGHTSOUTSD.config_icon_high_contrast_mode"),
         hint: game.i18n.localize("LIGHTSOUTSD.config_icon_high_contrast_mode_help"),
-        scope: "world",
-        config: true,
-        requiresReload: true,
-        type: Boolean,
-        default: false
-    });
-
-    game.settings.register("lights-out-theme-shadowdark", 'party_panel_visibility', {
-        name: game.i18n.localize("LIGHTSOUTSD.config_party_panel_visibility"),
-        hint: game.i18n.localize("LIGHTSOUTSD.config_party_panel_visibility_help"),
-        scope: "world",
-        config: true,
-        requiresReload: true,
-        type: Number,
-        choices: {
-            0: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_0"),
-            1: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_1"),
-            2: game.i18n.localize("LIGHTSOUTSD.config_visibility_option_2")
-        },
-        default: 2
-      });
-    
-    game.settings.register("lights-out-theme-shadowdark", "hide_party_health", {
-        name: game.i18n.localize("LIGHTSOUTSD.config_hide_party_health"),
-        hint: game.i18n.localize("LIGHTSOUTSD.config_hide_party_health_help"),
         scope: "world",
         config: true,
         requiresReload: true,

--- a/styles/ui.css
+++ b/styles/ui.css
@@ -822,6 +822,12 @@ section.effect-panel {
   box-shadow: 0px 1px 0 1px rgba(255, 255, 255, 0.4) inset;
 }
 
+#player-character .character-health .bar.hidden,
+#party .character-health .bar.hidden {
+  background: linear-gradient(180deg, #504f4f, #504f4f);
+}
+
+
 #player-character .character-health .bar.healthy,
 #party .character-health .bar.healthy {
   background: linear-gradient(180deg, #de2f2d, #a41413ff);

--- a/styles/ui.css
+++ b/styles/ui.css
@@ -825,11 +825,10 @@ section.effect-panel {
   box-shadow: 0px 1px 0 1px rgba(255, 255, 255, 0.4) inset;
 }
 
-#player-character .character-health .bar.hidden,
-#party .character-health .bar.hidden {
-  background: linear-gradient(180deg, #504f4f, #504f4f);
+#party .character-health .bar.unknown {
+  background: linear-gradient(180deg, #323232, #292929);
+  width: 100%;
 }
-
 
 #player-character .character-health .bar.healthy,
 #party .character-health .bar.healthy {

--- a/templates/party.hbs
+++ b/templates/party.hbs
@@ -1,4 +1,3 @@
-{{#if partyVisibility}}
 <div class="party-characters">
     {{#each characters as |c|}}
     <div class="party-character">
@@ -14,15 +13,14 @@
                 </div>
                 <div class="character-health">
                     <div class="bar-wrapper">
-                        {{#if ../playerHealthVisibility}}
-                            <div class="bar {{hp.status}}" style="width: {{hp.percent}}%"></div>
-
-                            <input type="text" class="current-health" data-value="{{hp.value}}" data-id="{{id}}"
-                                value="{{hp.value}}" />
-                            <span class="divider">/</span>
-                            <input type="text" value="{{hp.max}}" disabled />
+                        {{#if (or (not ../hidePartyHealth) (eq c.id ../userCharacterId))}}
+                        <div class="bar {{hp.status}}" style="width: {{hp.percent}}%"></div>
+                        <input type="text" class="current-health" data-value="{{hp.value}}" data-id="{{c.id}}"
+                            value="{{hp.value}}" />
+                        <span class="divider">/</span>
+                        <input type="text" value="{{hp.max}}" disabled />
                         {{else}}
-                            <div class="bar hidden" style="width: 99%"></div>
+                        <div class="bar hidden" style="width: 99%"></div>
                         {{/if}}
                     </div>
                 </div>
@@ -31,4 +29,3 @@
     </div>
     {{/each}}
 </div>
-{{/if}}

--- a/templates/party.hbs
+++ b/templates/party.hbs
@@ -1,5 +1,4 @@
 {{#if partyVisibility}}
-    <div>Party is visible!</div>
     {{#each characters as |c|}}
     <div class="party-character">
         <div class="character-picture" data-id="{{c.id}}">
@@ -14,18 +13,20 @@
                 </div>
                 <div class="character-health">
                     <div class="bar-wrapper">
-                        <div class="bar {{hp.status}}" style="width: {{hp.percent}}%"></div>
+                        {{#if playerHealthVisibility}}
+                            <div class="bar {{hp.status}}" style="width: {{hp.percent}}%"></div>
 
-                        <input type="text" class="current-health" data-value="{{hp.value}}" data-id="{{id}}"
-                            value="{{hp.value}}" />
-                        <span class="divider">/</span>
-                        <input type="text" value="{{hp.max}}" disabled />
+                            <input type="text" class="current-health" data-value="{{hp.value}}" data-id="{{id}}"
+                                value="{{hp.value}}" />
+                            <span class="divider">/</span>
+                            <input type="text" value="{{hp.max}}" disabled />
+                        {{else}}
+                            <div class="bar hidden" style="width: 99%"></div>
+                        {{/if}}
                     </div>
                 </div>
             </div>
         </div>
     </div>
     {{/each}}
-{{else}}
-  <div>Party is HIDDEN!</div>
 {{/if}}

--- a/templates/party.hbs
+++ b/templates/party.hbs
@@ -1,4 +1,5 @@
 {{#if partyVisibility}}
+    <div>Party is visible!</div>
     {{#each characters as |c|}}
     <div class="party-character">
         <div class="character-picture" data-id="{{c.id}}">
@@ -25,4 +26,6 @@
         </div>
     </div>
     {{/each}}
+{{else}}
+  <div>Party is HIDDEN!</div>
 {{/if}}

--- a/templates/party.hbs
+++ b/templates/party.hbs
@@ -13,7 +13,7 @@
                 </div>
                 <div class="character-health">
                     <div class="bar-wrapper">
-                        {{#if playerHealthVisibility}}
+                        {{#if ../playerHealthVisibility}}
                             <div class="bar {{hp.status}}" style="width: {{hp.percent}}%"></div>
 
                             <input type="text" class="current-health" data-value="{{hp.value}}" data-id="{{id}}"

--- a/templates/party.hbs
+++ b/templates/party.hbs
@@ -20,7 +20,7 @@
                         <span class="divider">/</span>
                         <input type="text" value="{{hp.max}}" disabled />
                         {{else}}
-                        <div class="bar hidden" style="width: 99%"></div>
+                        <div class="bar unknown"></div>
                         {{/if}}
                     </div>
                 </div>

--- a/templates/party.hbs
+++ b/templates/party.hbs
@@ -1,26 +1,28 @@
-{{#each characters as |c|}}
-<div class="party-character">
-    <div class="character-picture" data-id="{{c.id}}">
-        <img src="{{c.picture}}" alt="{{c.name}}" />
-    </div>
+{{#if partyVisibility}}
+    {{#each characters as |c|}}
+    <div class="party-character">
+        <div class="character-picture" data-id="{{c.id}}">
+            <img src="{{c.picture}}" alt="{{c.name}}" />
+        </div>
 
-    <div class="character-info">
-        <div class="character-info-wrapper">
-            <div class="character-details">
-                <div class="character-name">{{c.name}}</div>
-                <div class="character-class {{c.class}}"></div>
-            </div>
-            <div class="character-health">
-                <div class="bar-wrapper">
-                    <div class="bar {{hp.status}}" style="width: {{hp.percent}}%"></div>
+        <div class="character-info">
+            <div class="character-info-wrapper">
+                <div class="character-details">
+                    <div class="character-name">{{c.name}}</div>
+                    <div class="character-class {{c.class}}"></div>
+                </div>
+                <div class="character-health">
+                    <div class="bar-wrapper">
+                        <div class="bar {{hp.status}}" style="width: {{hp.percent}}%"></div>
 
-                    <input type="text" class="current-health" data-value="{{hp.value}}" data-id="{{id}}"
-                        value="{{hp.value}}" />
-                    <span class="divider">/</span>
-                    <input type="text" value="{{hp.max}}" disabled />
+                        <input type="text" class="current-health" data-value="{{hp.value}}" data-id="{{id}}"
+                            value="{{hp.value}}" />
+                        <span class="divider">/</span>
+                        <input type="text" value="{{hp.max}}" disabled />
+                    </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-{{/each}}
+    {{/each}}
+{{/if}}


### PR DESCRIPTION
Provides a baseline for controlling party details. 
+ Adds boolean for showing party details
+ Add boolean for showing party details player health

Starting point for https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/issues/43
Starting point for https://github.com/ronijaakkola/foundryvtt-lights-out-theme-shadowdark/issues/42


Next steps:
1. Mature control for party details toggle to allow for "none", "dm", "player" selection
2. Mature controls to allow for party details health toggle for "none", "player", "player+npc"