### PR TITLE
Fixes #48

### DIFF
--- a/scripts/actions.js
+++ b/scripts/actions.js
@@ -1,21 +1,12 @@
-export function openSheet() {
-  let actor;
-
-  if (this.dataset.token === "true") {
-    let scene = game.canvas.scene;
-    actor = scene.tokens.find(item => item.delta.id === this.dataset.id).actor;
-  }
-  else {
-    actor = game.actors.get(this.dataset.id);
-  }
-
+export async function openSheet() {
+  const actor = await fromUuid(this.dataset.uuid);
   if (actor) {
     actor.sheet.render(true);
   }
 }
 
-export function selectToken() {
-  const actor = game.actors.get(this.dataset.id);
+export async function selectToken() {
+  const actor = await fromUuid(this.dataset.uuid);
   if (!actor) return;
 
   const tokens = actor.getActiveTokens();
@@ -24,16 +15,15 @@ export function selectToken() {
   }
 }
 
-export function changeLuck() {
-  let actor = game.actors.get(this.dataset.id);
-
+export async function changeLuck() {
+  const actor = await fromUuid(this.dataset.uuid);
   if (actor) {
     actor.update({ "system.luck.available": !actor.system.luck.available });
   }
 }
 
-export function changePulpLuck(_, change) {
-  let actor = game.actors.get(this.dataset.id);
+export async function changePulpLuck(_, change) {
+  const actor = await fromUuid(this.dataset.uuid);
 
   if (actor) {
     let luckValue = parseInt(actor.system.luck.remaining + change);

--- a/scripts/apps/CharacterPanelApp.js
+++ b/scripts/apps/CharacterPanelApp.js
@@ -54,7 +54,7 @@ export class CharacterPanelApp extends HandlebarsApplicationMixin(ApplicationV2)
 
     _prepareContext(options) {
         return {
-            id: this.characterData.id,
+            uuid: this.characterData.uuid,
             isPlayer: this.characterData.isPlayer,
             isToken: this.characterData.isToken,
             name: this.characterData.name,

--- a/scripts/apps/PartyPanelApp.js
+++ b/scripts/apps/PartyPanelApp.js
@@ -36,11 +36,11 @@ export class PartyPanelApp extends HandlebarsApplicationMixin(ApplicationV2) {
     _prepareContext(options) {
         const hidePartyHealth = game.settings.get("lights-out-theme-shadowdark", "hide_party_health");
         const isGM = game.user.isGM;
-        const userCharacterId = game.user.character?.id;
+        const userCharacterUuid = game.user.character?.uuid;
 
         return {
             hidePartyHealth: isGM ? false : hidePartyHealth, // GMs always sees health
-            userCharacterId: userCharacterId,
+            userCharacterUuid: userCharacterUuid,
             characters: this.partyData
         };
     }

--- a/scripts/character.js
+++ b/scripts/character.js
@@ -62,7 +62,7 @@ export async function characterData(c) {
   }
   
   return {
-    id: c.id,
+    uuid: c.uuid,
     isPlayer: c.type == "Player",
     isToken: false,
     name: c.name,
@@ -82,48 +82,28 @@ export async function characterData(c) {
   };
 }
 
-export async function tokenData(t) {
-  const actor = game.actors.get(t.actorId);
+export async function tokenData(token) {
+  const actor = token?.actor;
   if (!actor) return;
-  
-  const actorSystem = actor.system;
-  const tokenSystem = t.delta.system;
 
-  const actorData = {
-    name: actor.name,
-    id: actor.id,
-    level: actorSystem.level.value,
-    armor: actorSystem.attributes.ac.value,
-    picture: actor.img,
-  }
-
-  const tokenData = {
-    name: t.delta.name,
-    id: t.delta.id,
-    level: tokenSystem.level?.value,
-    armor: tokenSystem.attributes?.ac?.value,
-    picture: t.delta.img,
-  }
-
-  const hp = tokenSystem.attributes?.hp.value ?? actorSystem.attributes?.hp.value;
-  const hpMax = tokenSystem.attributes?.hp.max ?? actorSystem.attributes?.hp.max;
+  const hp = actor.system.attributes?.hp.value;
+  const hpMax = actor.system.attributes?.hp.max;
   const hpPercent = calculateHpPercent(hp, hpMax);
+  const status = hpStatus(hpPercent);
 
-  // Combine actor and token data. This way we can
-  // show what is actually set in the sheet.
   return {
-    id: tokenData.id ?? actorData.id,
+    uuid: actor.uuid,
     isPlayer: false,
     isToken: true,
-    name: tokenData.name ?? actorData.name,
-    level: tokenData.level ?? actorData.level,
-    armor: tokenData.armor ?? actorData.armor,
-    picture: tokenData.picture ?? actorData.picture,
+    name: actor.name,
+    level: actor.system.level.value,
+    armor: actor.system.attributes.ac.value,
+    picture: token.img ?? actor.img,
     hp: {
       value: hp,
       max: hpMax,
       percent: hpPercent,
-      status: hpStatus(hpPercent),
+      status: status,
     },
   };
 }

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -32,7 +32,7 @@ export function setupHealthPointsTracker(element) {
         this.value = this.dataset.value;
     });
 
-    element.addEventListener("keyup", function (e) {
+    element.addEventListener("keyup", async function (e) {
         if (e.keyCode !== 13) {
             return;
         }
@@ -40,13 +40,7 @@ export function setupHealthPointsTracker(element) {
         e.preventDefault();
         e.stopPropagation();
 
-        let actor;
-        if (this.dataset.token === "true") {
-            let scene = game.canvas.scene;
-            actor = scene.tokens.find(item => item.delta.id === this.dataset.id).actor;
-        } else {
-            actor = game.actors.get(this.dataset.id);
-        }
+        let actor = await fromUuid(this.dataset.uuid);
 
         if (!actor) {
             return;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -109,7 +109,7 @@ Hooks.on("rtcSettingsChanged", async (settings, changes) => {
 });
 
 Hooks.on("updateActor", async function (actor) {
-  if (game.user.isGM || actor.id === getCharacter()?.id) {
+  if (game.user.isGM || actor.uuid === getCharacter()?.uuid) {
     await renderCharacter();
   }
   

--- a/templates/character.hbs
+++ b/templates/character.hbs
@@ -3,7 +3,7 @@
         <form class="character-attrs">
             <div class="bar-wrapper">
                 {{#if isPlayer}}
-                <div class="attr" id="luck-attr" data-id="{{id}}">
+                <div class="attr" id="luck-attr" data-uuid="{{uuid}}">
                     <label>{{localize "LIGHTSOUTSD.luck"}}</label>
                     <span>{{luck}}</span>
                 </div>
@@ -19,7 +19,7 @@
         <div class="character-picture">
             <img class="character-img" src="{{picture}}" alt="{{name}}" />
 
-            <div class="sheet" data-id="{{id}}" data-token={{isToken}}>
+            <div class="sheet" data-uuid="{{uuid}}" data-token={{isToken}}>
                 {{localize "LIGHTSOUTSD.open_sheet"}}
             </div>
 
@@ -33,7 +33,7 @@
             <div class="bar-wrapper">
                 <div class="bar {{hp.status}}" style="width: {{hp.percent}}%"></div>
 
-                <input type="text" id="current-health" data-value="{{hp.value}}" data-id="{{id}}" data-token={{isToken}}
+                <input type="text" id="current-health" data-value="{{hp.value}}" data-uuid="{{uuid}}" data-token={{isToken}}
                     value="{{hp.value}}" />
                 <span class="divider">/</span>
                 <input type="text" value="{{hp.max}}" disabled />

--- a/templates/party.hbs
+++ b/templates/party.hbs
@@ -1,7 +1,7 @@
 <div class="party-characters">
     {{#each characters as |c|}}
     <div class="party-character">
-        <div class="character-picture" data-id="{{c.id}}">
+        <div class="character-picture" data-uuid="{{c.uuid}}">
             <img src="{{c.picture}}" alt="{{c.name}}" />
         </div>
 
@@ -13,9 +13,9 @@
                 </div>
                 <div class="character-health">
                     <div class="bar-wrapper">
-                        {{#if (or (not ../hidePartyHealth) (eq c.id ../userCharacterId))}}
+                        {{#if (or (not ../hidePartyHealth) (eq c.uuid ../userCharacterUuid))}}
                         <div class="bar {{hp.status}}" style="width: {{hp.percent}}%"></div>
-                        <input type="text" class="current-health" data-value="{{hp.value}}" data-id="{{c.id}}"
+                        <input type="text" class="current-health" data-value="{{hp.value}}" data-uuid="{{c.uuid}}"
                             value="{{hp.value}}" />
                         <span class="divider">/</span>
                         <input type="text" value="{{hp.max}}" disabled />


### PR DESCRIPTION
The issues behind #48 is the complex logic used in trying to select embedded actor objects from NPC tokens. `token.actor` will always point to the correct actor object for that token. Since non actor linked tokens have their actor object stored as an embedded object, the most efficient way to access them is via a uuid. This approach has an added benefit of working in all cases, for character and npc token thus reducing the need for if then logic.

@ronijaakkola Other code clean up is possible, such as combining getCharacterData and getTokenData into one function as they are very similar now.